### PR TITLE
updated xpath filters for new fcrepo combined ontology

### DIFF
--- a/src/test/java/org/fcrepo/camel/integration/FedoraFileIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FedoraFileIT.java
@@ -115,7 +115,7 @@ public class FedoraFileIT extends CamelTestSupport {
                     .to(fcrepo_uri)
                     .filter().xpath(
                         "/rdf:RDF/rdf:Description/rdf:type" +
-                        "[@rdf:resource='http://fedora.info/definitions/v4/rest-api#NonRdfSourceDescription']", ns)
+                        "[@rdf:resource='http://fedora.info/definitions/v4/repository#Binary']", ns)
                     .to("mock:result");
 
                 from("direct:file")
@@ -124,7 +124,6 @@ public class FedoraFileIT extends CamelTestSupport {
 
                 from("direct:teardown")
                     .to(fcrepo_uri)
-                    .log("TEST TEARDOWN: ${header.FCREPO_IDENTIFIER}")
                     .to(fcrepo_uri + "?tombstone=true");
             }
         };

--- a/src/test/java/org/fcrepo/camel/integration/FedoraPathIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FedoraPathIT.java
@@ -96,14 +96,14 @@ public class FedoraPathIT extends CamelTestSupport {
                     .to(fcrepo_uri)
                     .filter().xpath(
                         "/rdf:RDF/rdf:Description/rdf:type" +
-                        "[@rdf:resource='http://fedora.info/definitions/v4/rest-api#Resource']", ns)
+                        "[@rdf:resource='http://fedora.info/definitions/v4/repository#Resource']", ns)
                     .to("mock:result");
 
                 from("direct:start2")
                     .to(fcrepo_uri + "/test/a/b/c/d")
                     .filter().xpath(
                         "/rdf:RDF/rdf:Description/rdf:type" +
-                        "[@rdf:resource='http://fedora.info/definitions/v4/rest-api#Resource']", ns)
+                        "[@rdf:resource='http://fedora.info/definitions/v4/repository#Resource']", ns)
                     .to("mock:result");
 
                 from("direct:teardown")

--- a/src/test/java/org/fcrepo/camel/integration/FedoraPostIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FedoraPostIT.java
@@ -100,7 +100,7 @@ public class FedoraPostIT extends CamelTestSupport {
                     .to(fcrepo_uri)
                     .filter().xpath(
                         "/rdf:RDF/rdf:Description/rdf:type" +
-                        "[@rdf:resource='http://fedora.info/definitions/v4/rest-api#Resource']", ns)
+                        "[@rdf:resource='http://fedora.info/definitions/v4/repository#Resource']", ns)
                     .split(titleXpath)
                     .to("mock:result");
 

--- a/src/test/java/org/fcrepo/camel/integration/FedoraPutIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FedoraPutIT.java
@@ -92,7 +92,7 @@ public class FedoraPutIT extends CamelTestSupport {
                     .to(fcrepo_uri)
                     .filter().xpath(
                         "/rdf:RDF/rdf:Description/rdf:type" +
-                        "[@rdf:resource='http://fedora.info/definitions/v4/rest-api#Resource']", ns)
+                        "[@rdf:resource='http://fedora.info/definitions/v4/repository#Resource']", ns)
                     .to("mock:result");
 
                 from("direct:teardown")


### PR DESCRIPTION
Changing the fcrepo ontology breaks the integration tests for fcrepo-camel. This fixes that.
