### PR TITLE
code cleanup: added missing RunWith attribute to integration tests

### DIFF
--- a/src/test/java/org/fcrepo/camel/integration/FedoraContentTypeHeaderIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FedoraContentTypeHeaderIT.java
@@ -26,7 +26,9 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * Test the retrieved content-type from a fcrepo endpoint
@@ -34,6 +36,7 @@ import org.springframework.test.context.ContextConfiguration;
  * @author Aaron Coburn
  * @since November 7, 2014
  */
+@RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration({"/spring-test/test-container.xml"})
 public class FedoraContentTypeHeaderIT extends CamelTestSupport {
 

--- a/src/test/java/org/fcrepo/camel/integration/FedoraFileIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FedoraFileIT.java
@@ -34,13 +34,16 @@ import org.apache.camel.builder.xml.Namespaces;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * Test adding a non-RDF resource
  * @author Aaron Coburn
  * @since November 7, 2014
  */
+@RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration({"/spring-test/test-container.xml"})
 public class FedoraFileIT extends CamelTestSupport {
 

--- a/src/test/java/org/fcrepo/camel/integration/FedoraPatchIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FedoraPatchIT.java
@@ -34,13 +34,16 @@ import org.apache.camel.builder.xml.XPathBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * Test updating a fedora object with sparql-update
  * @author Aaron Coburn
  * @since November 7, 2014
  */
+@RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration({"/spring-test/test-container.xml"})
 public class FedoraPatchIT extends CamelTestSupport {
 

--- a/src/test/java/org/fcrepo/camel/integration/FedoraPathIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FedoraPathIT.java
@@ -33,13 +33,16 @@ import org.apache.camel.builder.xml.Namespaces;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * Test adding a resource at a specific path
  * @author Aaron Coburn
  * @since November 7, 2014
  */
+@RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration({"/spring-test/test-container.xml"})
 public class FedoraPathIT extends CamelTestSupport {
 

--- a/src/test/java/org/fcrepo/camel/integration/FedoraPostIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FedoraPostIT.java
@@ -34,13 +34,16 @@ import org.apache.camel.builder.xml.XPathBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * Test adding a new resource with POST
  * @author Aaron Coburn
  * @since November 7, 2014
  */
+@RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration({"/spring-test/test-container.xml"})
 public class FedoraPostIT extends CamelTestSupport {
 

--- a/src/test/java/org/fcrepo/camel/integration/FedoraPutIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FedoraPutIT.java
@@ -32,13 +32,16 @@ import org.apache.camel.builder.xml.Namespaces;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * Test adding an RDF resource with PUT
  * @author Aaron Coburn
  * @since November 7, 2014
  */
+@RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration({"/spring-test/test-container.xml"})
 public class FedoraPutIT extends CamelTestSupport {
 

--- a/src/test/java/org/fcrepo/camel/integration/FedoraTransformIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FedoraTransformIT.java
@@ -31,13 +31,16 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * Test the fcr:transform endpoint
  * @author Aaron Coburn
  * @since November 7, 2014
  */
+@RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration({"/spring-test/test-container.xml"})
 public class FedoraTransformIT extends CamelTestSupport {
 


### PR DESCRIPTION
jenkins build was failing because certain integration tests were missing the RunWith(...) attribute
