### PR TITLE
fixed incorrectly declared namespace values

### DIFF
--- a/src/test/java/org/fcrepo/camel/SparqlDeleteProcessorTest.java
+++ b/src/test/java/org/fcrepo/camel/SparqlDeleteProcessorTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.camel.integration;
+package org.fcrepo.camel;
 
 import static org.apache.camel.Exchange.HTTP_METHOD;
 import static org.apache.camel.Exchange.CONTENT_TYPE;

--- a/src/test/java/org/fcrepo/camel/SparqlDescribeProcessorTest.java
+++ b/src/test/java/org/fcrepo/camel/SparqlDescribeProcessorTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.camel.integration;
+package org.fcrepo.camel;
 
 import static org.apache.camel.Exchange.HTTP_METHOD;
 import static org.apache.camel.Exchange.CONTENT_TYPE;

--- a/src/test/java/org/fcrepo/camel/SparqlInsertProcessorTest.java
+++ b/src/test/java/org/fcrepo/camel/SparqlInsertProcessorTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.camel.integration;
+package org.fcrepo.camel;
 
 import static org.apache.camel.Exchange.HTTP_METHOD;
 import static org.apache.commons.lang3.StringUtils.normalizeSpace;


### PR DESCRIPTION
The Processor-related unit tests should have a package NS declared as org.fcrepo.camel, but instead they were using org.fcrepo.camel.integration
