### PR TITLE
Add fcrepo-metrics test dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-metrics</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>${httpclient.version}</version>


### PR DESCRIPTION
This should not be necessary, but the dependency loading in Jenkins
  indicates that fcrepo-metrics is not always loaded in time.
http://jenkins.fcrepo.org/job/fcrepo-camel/org.fcrepo.camel$fcrepo-camel/21/testReport/junit/org.fcrepo.camel.integration/FedoraFileIT/testFile/
