### PR TITLE
osgi deployment requires that getters and setters use the same types

### DIFF
--- a/src/main/java/org/fcrepo/camel/FedoraEndpoint.java
+++ b/src/main/java/org/fcrepo/camel/FedoraEndpoint.java
@@ -209,8 +209,8 @@ public class FedoraEndpoint extends DefaultEndpoint {
      * @param metadata whether to retrieve rdf metadata for non-rdf nodes
      */
     @ManagedAttribute(description = "Whether to retrieve the /fcr:metadata endpoint for Binary nodes")
-    public void setMetadata(final String metadata) {
-        this.metadata = Boolean.valueOf(metadata);
+    public void setMetadata(final Boolean metadata) {
+        this.metadata = metadata;
     }
 
     /**
@@ -226,8 +226,8 @@ public class FedoraEndpoint extends DefaultEndpoint {
      * @param throwOnFailure whether non-2xx HTTP response codes throw exceptions
      */
     @ManagedAttribute(description = "Whether non 2xx response codes should throw an exception")
-    public void setThrowExceptionOnFailure(final String throwOnFailure) {
-        this.throwExceptionOnFailure = Boolean.valueOf(throwOnFailure);
+    public void setThrowExceptionOnFailure(final Boolean throwOnFailure) {
+        this.throwExceptionOnFailure = throwOnFailure;
     }
 
     /**
@@ -260,8 +260,8 @@ public class FedoraEndpoint extends DefaultEndpoint {
      * @param tombstone whether to access the /fcr:tombstone endpoint for a resource
      */
     @ManagedAttribute(description = "Whether to use the /fcr:tombstone endpoint on objects")
-    public void setTombstone(final String tombstone) {
-        this.tombstone = Boolean.valueOf(tombstone);
+    public void setTombstone(final Boolean tombstone) {
+        this.tombstone = tombstone;
     }
 
     /**

--- a/src/test/java/org/fcrepo/camel/FedoraEndpointTest.java
+++ b/src/test/java/org/fcrepo/camel/FedoraEndpointTest.java
@@ -65,7 +65,7 @@ public class FedoraEndpointTest {
     public void testTombstone() {
         final FedoraEndpoint testEndpoint = new FedoraEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
         assertEquals(false, testEndpoint.getTombstone());
-        testEndpoint.setTombstone("true");
+        testEndpoint.setTombstone(true);
         assertEquals(true, testEndpoint.getTombstone());
     }
 
@@ -82,7 +82,7 @@ public class FedoraEndpointTest {
     public void testThrowExceptionOnFailure() {
         final FedoraEndpoint testEndpoint = new FedoraEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
         assertEquals(true, testEndpoint.getThrowExceptionOnFailure());
-        testEndpoint.setThrowExceptionOnFailure("false");
+        testEndpoint.setThrowExceptionOnFailure(false);
         assertEquals(false, testEndpoint.getThrowExceptionOnFailure());
     }
 
@@ -90,7 +90,7 @@ public class FedoraEndpointTest {
     public void testMetadata() {
         final FedoraEndpoint testEndpoint = new FedoraEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
         assertEquals(true, testEndpoint.getMetadata());
-        testEndpoint.setMetadata("false");
+        testEndpoint.setMetadata(false);
         assertEquals(false, testEndpoint.getMetadata());
     }
 


### PR DESCRIPTION
when deploying the camel component in an OSGi container (e.g. karaf), startup fails because the getters/setters are of different types for certain endpoint attributes. This fixes the error.
