### PR TITLE
fixed travis-ci link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The **fcrepo:** component provides access to an external
 [API](https://wiki.duraspace.org/display/FEDORA40/RESTful+HTTP+API+-+Containers)
 for use with [Apache Camel](https://camel.apache.org).
 
-[![Build Status](https://travis-ci.org/fcrepo4-labs/fcrepo-camel.png?branch=master)](https://travis-ci.org/fcrepo4-labs/fcrepo-camel)
+[![Build Status](https://travis-ci.org/fcrepo4/fcrepo-camel.png?branch=master)](https://travis-ci.org/fcrepo4/fcrepo-camel)
 
 URI format
 ----------


### PR DESCRIPTION
Related to the migration from fcrepo4-labs to fcrepo4, this fixes a broken link from the travis-ci build status