### PR TITLE
added FcrepoConfiguration class and associated tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ Setting basic authentication
 | `authPassword` | `null`          | Password for authentication |
 | `authHost`     | `null`          | The host name for authentication |
 
+Configuring the fcrepo component
+--------------------------------
+
+In addition to configuring the `fcrepo` component with URI options on each request, it is also
+sometimes convenient to set up component-wide configurations. This can be done via Spring
+(or Blueprint), like so:
+
+    <bean id="fcrepo" class="org.fcrepo.camel.FcrepoComponent">
+      <property name="authUsername" value="${fcrepo.authUsername}"/>
+      <property name="authPassword" value="${fcrepo.authPassword}"/>
+      <property name="authHost" value="${fcrepo.authHost}"/>
+      <property name="secure" value="${fcrepo.secure}"/>
+    </bean>
+
 
 Message headers
 ---------------

--- a/src/main/java/org/fcrepo/camel/FcrepoComponent.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoComponent.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
-import org.apache.camel.impl.DefaultComponent;
+import org.apache.camel.impl.UriEndpointComponent;
 import org.slf4j.Logger;
 
 /**
@@ -29,7 +29,9 @@ import org.slf4j.Logger;
  * @author Aaron Coburn
  * @since October 20, 2014
  */
-public class FcrepoComponent extends DefaultComponent {
+public class FcrepoComponent extends UriEndpointComponent {
+
+    private FcrepoConfiguration configuration;
 
     private static final Logger LOGGER  = getLogger(FcrepoComponent.class);
 
@@ -37,7 +39,7 @@ public class FcrepoComponent extends DefaultComponent {
      * Create a FcrepoComponent independent of a CamelContext.
      */
     public FcrepoComponent() {
-        super();
+        super(FcrepoEndpoint.class);
     }
 
     /**
@@ -45,7 +47,66 @@ public class FcrepoComponent extends DefaultComponent {
      * @param context the CamelContext
      */
     public FcrepoComponent(final CamelContext context) {
-        super(context);
+        super(context, FcrepoEndpoint.class);
+    }
+
+    /**
+     * Given a FcrepoConfiguration, create a FcrepoComponent instance.
+     * @param config the FcrepoConfiguration
+     */
+    public FcrepoComponent(final FcrepoConfiguration config) {
+        super(FcrepoEndpoint.class);
+        this.configuration = config;
+    }
+
+    /**
+     * Get the component's configuration.
+     */
+    public FcrepoConfiguration getConfiguration() {
+        if (configuration == null) {
+            configuration = new FcrepoConfiguration();
+        }
+        return configuration;
+    }
+
+    /**
+     * Set the component's configuration.
+     */
+    public void setConfiguration(final FcrepoConfiguration config) {
+        this.configuration = config;
+    }
+
+    /**
+     * set the authUsername value component-wide.
+     * @param username the authentication username.
+     */
+    public void setAuthUsername(final String username) {
+        getConfiguration().setAuthUsername(username);
+    }
+
+    /**
+     * set the authPassword value component-wide.
+     * @param password the authentication password.
+     */
+    public void setAuthPassword(final String password) {
+        getConfiguration().setAuthPassword(password);
+    }
+
+    /**
+     * set the authHost value component-wide.
+     * @param host the authentication host realm.
+     */
+    public void setAuthHost(final String host) {
+        getConfiguration().setAuthHost(host);
+    }
+
+    /**
+     * set whether to use the https scheme when connecting
+     * to the fedora server.
+     * @param secure whether to use the https scheme
+     */
+    public void setSecure(final Boolean secure) {
+        getConfiguration().setSecure(secure);
     }
 
     /**
@@ -56,7 +117,15 @@ public class FcrepoComponent extends DefaultComponent {
      */
     @Override
     protected Endpoint createEndpoint(final String uri, final String remaining, final Map<String, Object> parameters) {
-        final Endpoint endpoint = new FcrepoEndpoint(uri, remaining, this);
+
+        FcrepoConfiguration newConfig;
+        if (configuration == null) {
+            newConfig = new FcrepoConfiguration();
+        } else {
+            newConfig = configuration.clone();
+        }
+
+        final Endpoint endpoint = new FcrepoEndpoint(uri, remaining, this, newConfig);
         endpoint.configureProperties(parameters);
         LOGGER.debug("Created Fcrepo Endpoint [{}]", endpoint);
         return endpoint;

--- a/src/main/java/org/fcrepo/camel/FcrepoConfiguration.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoConfiguration.java
@@ -1,0 +1,278 @@
+/**
+ * Copyright 2014 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.camel;
+
+import org.apache.camel.spi.UriParam;
+import org.apache.camel.spi.UriParams;
+import org.apache.camel.RuntimeCamelException;
+
+/**
+ * An FcrepoConfiguration class.
+ * @author Aaron Coburn
+ * @since Jan 20, 2015
+ */
+@UriParams
+public class FcrepoConfiguration implements Cloneable {
+
+    private String baseUrl = "";
+
+    @UriParam
+    private String contentType = null;
+
+    @UriParam
+    private String accept = null;
+
+    @UriParam
+    private String transform = null;
+
+    @UriParam
+    private String authUsername = null;
+
+    @UriParam
+    private String authPassword = null;
+
+    @UriParam
+    private String authHost = null;
+
+    @UriParam
+    private Boolean tombstone = false;
+
+    @UriParam
+    private Boolean metadata = true;
+
+    @UriParam
+    private Boolean throwExceptionOnFailure = true;
+
+    @UriParam
+    private String preferInclude = null;
+
+    @UriParam
+    private String preferOmit = null;
+
+    @UriParam
+    private Boolean secure = false;
+
+    /**
+     * Create a new FcrepoConfiguration object
+     */
+    public FcrepoConfiguration() {
+        super();
+    }
+
+    /**
+     * Copy an FcrepoConfiguration object.
+     */
+    @Override
+    public FcrepoConfiguration clone() {
+        try {
+            return (FcrepoConfiguration) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new RuntimeCamelException(e);
+        }
+    }
+
+   /**
+     * baseUrl setter
+     * @param url the baseUrl string
+     */
+    public void setBaseUrl(final String url) {
+        this.baseUrl = url;
+    }
+
+    /**
+     * baseUrl getter
+     */
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    /**
+     * accept setter
+     * @param type the content-type for Accept headers
+     */
+    public void setAccept(final String type) {
+        this.accept = type.replaceAll(" ", "+");
+    }
+
+    /**
+     * accept getter
+     */
+    public String getAccept() {
+        return accept;
+    }
+
+    /**
+     * contentType setter
+     * @param type the content-type for Content-Type headers
+     */
+    public void setContentType(final String type) {
+        this.contentType = type.replaceAll(" ", "+");
+    }
+
+    /**
+     * contentType getter
+     */
+    public String getContentType() {
+        return contentType;
+    }
+
+    /**
+     * authUsername setter
+     * @param username used for authentication
+     */
+    public void setAuthUsername(final String username) {
+        this.authUsername = username;
+    }
+
+    /**
+     * authUsername getter
+     */
+    public String getAuthUsername() {
+        return authUsername;
+    }
+
+    /**
+     * authPassword setter
+     * @param password used for authentication
+     */
+    public void setAuthPassword(final String password) {
+        this.authPassword = password;
+    }
+
+    /**
+     * authPassword getter
+     */
+    public String getAuthPassword() {
+        return authPassword;
+    }
+
+    /**
+     * authHost setter
+     * @param host used for authentication
+     */
+    public void setAuthHost(final String host) {
+        this.authHost = host;
+    }
+
+    /**
+     * authHost getter
+     */
+    public String getAuthHost() {
+        return authHost;
+    }
+
+    /**
+     * metadata setter
+     * @param metadata whether to retrieve rdf metadata for non-rdf nodes
+     */
+    public void setMetadata(final Boolean metadata) {
+        this.metadata = metadata;
+    }
+
+    /**
+     * metadata getter
+     */
+    public Boolean getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * throwExceptionOnFailure setter
+     * @param throwOnFailure whether non-2xx HTTP response codes throw exceptions
+     */
+    public void setThrowExceptionOnFailure(final Boolean throwOnFailure) {
+        this.throwExceptionOnFailure = throwOnFailure;
+    }
+
+    /**
+     * throwExceptionOnFailure getter
+     */
+    public Boolean getThrowExceptionOnFailure() {
+        return throwExceptionOnFailure;
+    }
+
+    /**
+     * transform setter
+     * @param transform define an LD-Path transform program for converting RDF to JSON
+     */
+    public void setTransform(final String transform) {
+        this.transform = transform;
+    }
+
+    /**
+     * transform getter
+     */
+    public String getTransform() {
+        return transform;
+    }
+
+    /**
+     * tombstone setter
+     * @param tombstone whether to access the /fcr:tombstone endpoint for a resource
+     */
+    public void setTombstone(final Boolean tombstone) {
+        this.tombstone = tombstone;
+    }
+
+    /**
+     * tombstone getter
+     */
+    public Boolean getTombstone() {
+        return tombstone;
+    }
+
+    /**
+     * preferInclude setter
+     */
+    public void setPreferInclude(final String include) {
+        this.preferInclude = include;
+    }
+
+    /**
+     * preferOmit getter
+     */
+    public String getPreferInclude() {
+        return preferInclude;
+    }
+
+    /**
+     * preferOmit setter
+     */
+    public void setPreferOmit(final String omit) {
+        this.preferOmit = omit;
+    }
+
+    /**
+     * preferOmit getter
+     */
+    public String getPreferOmit() {
+        return preferOmit;
+    }
+
+    /**
+     * secure getter
+     */
+    public Boolean getSecure() {
+        return secure;
+    }
+
+    /**
+     * secure setter
+     */
+    public void setSecure(final Boolean secure) {
+        this.secure = secure;
+    }
+}

--- a/src/main/java/org/fcrepo/camel/FcrepoEndpoint.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoEndpoint.java
@@ -34,43 +34,8 @@ import org.apache.camel.spi.UriParam;
 @UriEndpoint(scheme = "fcrepo")
 public class FcrepoEndpoint extends DefaultEndpoint {
 
-    private String baseUrl = "";
-
     @UriParam
-    private String contentType = null;
-
-    @UriParam
-    private String accept = null;
-
-    @UriParam
-    private String transform = null;
-
-    @UriParam
-    private String authUsername = null;
-
-    @UriParam
-    private String authPassword = null;
-
-    @UriParam
-    private String authHost = null;
-
-    @UriParam
-    private Boolean secure = false;
-
-    @UriParam
-    private Boolean tombstone = false;
-
-    @UriParam
-    private Boolean metadata = true;
-
-    @UriParam
-    private Boolean throwExceptionOnFailure = true;
-
-    @UriParam
-    private String preferInclude = null;
-
-    @UriParam
-    private String preferOmit = null;
+    private FcrepoConfiguration configuration;
 
     /**
      * Create a FcrepoEndpoint with a uri, path and component
@@ -78,8 +43,10 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      * @param remaining any path values on the endpoint uri
      * @param component an existing component value
      */
-    public FcrepoEndpoint(final String uri, final String remaining, final FcrepoComponent component) {
+    public FcrepoEndpoint(final String uri, final String remaining, final FcrepoComponent component,
+            final FcrepoConfiguration configuration) {
         super(uri, component);
+        this.configuration = configuration;
         this.setBaseUrl(remaining);
     }
 
@@ -108,18 +75,33 @@ public class FcrepoEndpoint extends DefaultEndpoint {
     }
 
     /**
+     * configuration getter
+     */
+    public FcrepoConfiguration getConfiguration() {
+        return configuration;
+    }
+
+    /**
+     * configuration setter
+     * @param config The FcrepoConfiguration
+     */
+    public void setConfiguration(final FcrepoConfiguration config) {
+        this.configuration = config;
+    }
+
+    /**
      * baseUrl setter
      * @param url the baseUrl string
      */
     public void setBaseUrl(final String url) {
-        this.baseUrl = url;
+        getConfiguration().setBaseUrl(url);
     }
 
     /**
      * baseUrl getter
      */
     public String getBaseUrl() {
-        return baseUrl;
+        return getConfiguration().getBaseUrl();
     }
 
     /**
@@ -128,7 +110,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Accept: Header")
     public void setAccept(final String type) {
-        this.accept = type.replaceAll(" ", "+");
+        getConfiguration().setAccept(type.replaceAll(" ", "+"));
     }
 
     /**
@@ -136,7 +118,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Accept: Header")
     public String getAccept() {
-        return accept;
+        return getConfiguration().getAccept();
     }
 
     /**
@@ -145,7 +127,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Content-Type: Header")
     public void setContentType(final String type) {
-        this.contentType = type.replaceAll(" ", "+");
+        getConfiguration().setContentType(type);
     }
 
     /**
@@ -153,7 +135,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Content-Type: Header")
     public String getContentType() {
-        return contentType;
+        return getConfiguration().getContentType();
     }
 
     /**
@@ -162,7 +144,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Username for authentication")
     public void setAuthUsername(final String username) {
-        this.authUsername = username;
+        getConfiguration().setAuthUsername(username);
     }
 
     /**
@@ -170,7 +152,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Username for authentication")
     public String getAuthUsername() {
-        return authUsername;
+        return getConfiguration().getAuthUsername();
     }
 
     /**
@@ -179,7 +161,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Password for authentication")
     public void setAuthPassword(final String password) {
-        this.authPassword = password;
+        getConfiguration().setAuthPassword(password);
     }
 
     /**
@@ -187,7 +169,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Password for authentication")
     public String getAuthPassword() {
-        return authPassword;
+        return getConfiguration().getAuthPassword();
     }
 
     /**
@@ -196,7 +178,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Hostname for authentication")
     public void setAuthHost(final String host) {
-        this.authHost = host;
+        getConfiguration().setAuthHost(host);
     }
 
     /**
@@ -204,7 +186,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Hostname for authentication")
     public String getAuthHost() {
-        return authHost;
+        return getConfiguration().getAuthHost();
     }
 
     /**
@@ -213,7 +195,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Whether to retrieve the /fcr:metadata endpoint for Binary nodes")
     public void setMetadata(final Boolean metadata) {
-        this.metadata = metadata;
+        getConfiguration().setMetadata(metadata);
     }
 
     /**
@@ -221,7 +203,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Whether to retrieve the /fcr:metadata endpoint for Binary nodes")
     public Boolean getMetadata() {
-        return metadata;
+        return getConfiguration().getMetadata();
     }
 
     /**
@@ -230,7 +212,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Whether non 2xx response codes should throw an exception")
     public void setThrowExceptionOnFailure(final Boolean throwOnFailure) {
-        this.throwExceptionOnFailure = throwOnFailure;
+        getConfiguration().setThrowExceptionOnFailure(throwOnFailure);
     }
 
     /**
@@ -238,7 +220,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Whether non 2xx response codes should throw an exception")
     public Boolean getThrowExceptionOnFailure() {
-        return throwExceptionOnFailure;
+        return getConfiguration().getThrowExceptionOnFailure();
     }
 
     /**
@@ -247,7 +229,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "The LDPath transform program to use")
     public void setTransform(final String transform) {
-        this.transform = transform;
+        getConfiguration().setTransform(transform);
     }
 
     /**
@@ -255,7 +237,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "The LDPath transform program to use")
     public String getTransform() {
-        return transform;
+        return getConfiguration().getTransform();
     }
 
     /**
@@ -264,7 +246,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Whether to use the /fcr:tombstone endpoint on objects")
     public void setTombstone(final Boolean tombstone) {
-        this.tombstone = tombstone;
+        getConfiguration().setTombstone(tombstone);
     }
 
     /**
@@ -272,7 +254,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Whether to use the /fcr:tombstone endpoint on objects")
     public Boolean getTombstone() {
-        return tombstone;
+        return getConfiguration().getTombstone();
     }
 
     /**
@@ -280,7 +262,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Whether to include a Prefer: return=representation; include=\"URI\" header")
     public void setPreferInclude(final String include) {
-        this.preferInclude = include;
+        getConfiguration().setPreferInclude(include);
     }
 
     /**
@@ -288,7 +270,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Whether to include a Prefer: return=representation; include=\"URI\" header")
     public String getPreferInclude() {
-        return preferInclude;
+        return getConfiguration().getPreferInclude();
     }
 
     /**
@@ -296,7 +278,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Whether to include a Prefer: return=representation; omit=\"URI\" header")
     public void setPreferOmit(final String omit) {
-        this.preferOmit = omit;
+        getConfiguration().setPreferOmit(omit);
     }
 
     /**
@@ -304,7 +286,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Whether to include a Prefer: return=representation; omit=\"URI\" header")
     public String getPreferOmit() {
-        return preferOmit;
+        return getConfiguration().getPreferOmit();
     }
 
     /**
@@ -312,7 +294,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Whether to use the https scheme with connections to Fedora")
     public void setSecure(final Boolean secure) {
-        this.secure = secure;
+        getConfiguration().setSecure(secure);
     }
 
     /**
@@ -320,7 +302,7 @@ public class FcrepoEndpoint extends DefaultEndpoint {
      */
     @ManagedAttribute(description = "Whether to use the https scheme with connections to Fedora")
     public Boolean getSecure() {
-        return secure;
+        return getConfiguration().getSecure();
     }
 
 }

--- a/src/main/java/org/fcrepo/camel/FcrepoEndpoint.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoEndpoint.java
@@ -23,7 +23,6 @@ import org.apache.camel.api.management.ManagedResource;
 import org.apache.camel.api.management.ManagedAttribute;
 import org.apache.camel.impl.DefaultEndpoint;
 import org.apache.camel.spi.UriEndpoint;
-import org.apache.camel.spi.UriParam;
 
 /**
  * Represents a Fcrepo endpoint.
@@ -34,7 +33,6 @@ import org.apache.camel.spi.UriParam;
 @UriEndpoint(scheme = "fcrepo")
 public class FcrepoEndpoint extends DefaultEndpoint {
 
-    @UriParam
     private FcrepoConfiguration configuration;
 
     /**

--- a/src/test/java/org/fcrepo/camel/FcrepoComponentTest.java
+++ b/src/test/java/org/fcrepo/camel/FcrepoComponentTest.java
@@ -50,6 +50,57 @@ public class FcrepoComponentTest {
     }
 
     @Test
+    public void testCreateEndpointFromConfig() {
+        final FcrepoConfiguration configuration = new FcrepoConfiguration();
+
+        configuration.setMetadata(false);
+
+        final FcrepoComponent testComponent = new FcrepoComponent(configuration);
+        final Endpoint testEndpoint = testComponent.createEndpoint(TEST_ENDPOINT_URI, "", EMPTY_MAP);
+        assertEquals(TEST_ENDPOINT_URI, testEndpoint.getEndpointUri());
+
+        assertEquals(false, testComponent.getConfiguration().getMetadata());
+    }
+
+    @Test
+    public void testPreConfiguredComponent() {
+        final FcrepoConfiguration config = new FcrepoConfiguration();
+        config.setAuthUsername("foo");
+        config.setAuthPassword("bar");
+        config.setAuthHost("baz");
+        config.setSecure(true);
+
+        final FcrepoComponent testComponent = new FcrepoComponent();
+
+        testComponent.setConfiguration(config);
+
+        final Endpoint testEndpoint = testComponent.createEndpoint(TEST_ENDPOINT_URI, "", EMPTY_MAP);
+
+        assertEquals(TEST_ENDPOINT_URI, testEndpoint.getEndpointUri());
+        assertEquals("foo", testComponent.getConfiguration().getAuthUsername());
+        assertEquals("bar", testComponent.getConfiguration().getAuthPassword());
+        assertEquals("baz", testComponent.getConfiguration().getAuthHost());
+        assertEquals(true, testComponent.getConfiguration().getSecure());
+    }
+
+    @Test
+    public void testPostConfiguredComponent() {
+        final FcrepoComponent testComponent = new FcrepoComponent();
+        testComponent.setAuthUsername("foo");
+        testComponent.setAuthPassword("bar");
+        testComponent.setAuthHost("baz");
+        testComponent.setSecure(true);
+
+        final Endpoint testEndpoint = testComponent.createEndpoint(TEST_ENDPOINT_URI, "", EMPTY_MAP);
+
+        assertEquals(TEST_ENDPOINT_URI, testEndpoint.getEndpointUri());
+        assertEquals("foo", testComponent.getConfiguration().getAuthUsername());
+        assertEquals("bar", testComponent.getConfiguration().getAuthPassword());
+        assertEquals("baz", testComponent.getConfiguration().getAuthHost());
+        assertEquals(true, testComponent.getConfiguration().getSecure());
+    }
+
+    @Test
     public void testCreateEndpointFromDefaultConstructor() {
         final FcrepoComponent testComponent = new FcrepoComponent();
         final Endpoint testEndpoint = testComponent.createEndpoint(TEST_ENDPOINT_URI, "", EMPTY_MAP);

--- a/src/test/java/org/fcrepo/camel/FcrepoEndpointTest.java
+++ b/src/test/java/org/fcrepo/camel/FcrepoEndpointTest.java
@@ -42,28 +42,41 @@ public class FcrepoEndpointTest {
     @Mock
     private Processor mockProcessor;
 
+    private FcrepoConfiguration testConfig = new FcrepoConfiguration();
+
     @Test(expected = RuntimeCamelException.class)
     public void testNoConsumerCanBeCreated() throws RuntimeCamelException {
-        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
+        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext, testConfig);
         testEndpoint.createConsumer(mockProcessor);
     }
 
     @Test
     public void testCreateProducer() {
-        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
+        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext, testConfig);
         final Producer testProducer = testEndpoint.createProducer();
         assertEquals(testEndpoint, testProducer.getEndpoint());
     }
 
     @Test
     public void testBaseUrl() {
-        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
+        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext, testConfig);
         assertEquals(testEndpoint.getBaseUrl(), FCREPO_PATH);
     }
 
     @Test
+    public void testConfiguration() {
+        final FcrepoConfiguration config = new FcrepoConfiguration();
+        config.setTombstone(true);
+
+        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext, testConfig);
+        assertEquals(false, testEndpoint.getTombstone());
+        testEndpoint.setConfiguration(config);
+        assertEquals(true, testEndpoint.getTombstone());
+    }
+
+    @Test
     public void testTombstone() {
-        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
+        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext, testConfig);
         assertEquals(false, testEndpoint.getTombstone());
         testEndpoint.setTombstone(true);
         assertEquals(true, testEndpoint.getTombstone());
@@ -71,7 +84,7 @@ public class FcrepoEndpointTest {
 
     @Test
     public void testTransform() {
-        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
+        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext, testConfig);
         final String transform = "default";
         assertEquals(null, testEndpoint.getTransform());
         testEndpoint.setTransform(transform);
@@ -80,7 +93,7 @@ public class FcrepoEndpointTest {
 
     @Test
     public void testThrowExceptionOnFailure() {
-        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
+        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext, testConfig);
         assertEquals(true, testEndpoint.getThrowExceptionOnFailure());
         testEndpoint.setThrowExceptionOnFailure(false);
         assertEquals(false, testEndpoint.getThrowExceptionOnFailure());
@@ -88,7 +101,7 @@ public class FcrepoEndpointTest {
 
     @Test
     public void testMetadata() {
-        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
+        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext, testConfig);
         assertEquals(true, testEndpoint.getMetadata());
         testEndpoint.setMetadata(false);
         assertEquals(false, testEndpoint.getMetadata());
@@ -96,7 +109,7 @@ public class FcrepoEndpointTest {
 
     @Test
     public void testAuthHost() {
-        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
+        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext, testConfig);
         final String authHost = "example.org";
         assertEquals(null, testEndpoint.getAuthHost());
         testEndpoint.setAuthHost(authHost);
@@ -105,7 +118,7 @@ public class FcrepoEndpointTest {
 
     @Test
     public void testAuthUser() {
-        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
+        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext, testConfig);
         final String authUser = "fedoraAdmin";
         assertEquals(null, testEndpoint.getAuthUsername());
         testEndpoint.setAuthUsername(authUser);
@@ -114,7 +127,7 @@ public class FcrepoEndpointTest {
 
     @Test
     public void testAuthPassword() {
-        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
+        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext, testConfig);
         final String authPassword = "foo";
         assertEquals(null, testEndpoint.getAuthPassword());
         testEndpoint.setAuthPassword(authPassword);
@@ -123,7 +136,7 @@ public class FcrepoEndpointTest {
 
     @Test
     public void testAccept() {
-        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
+        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext, testConfig);
         final String accept1 = "application/rdf+xml";
         final String accept2 = "text/turtle";
         final String accept3 = "application/ld+json";
@@ -141,7 +154,7 @@ public class FcrepoEndpointTest {
 
     @Test
     public void testContentType() {
-        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
+        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext, testConfig);
         final String contentType1 = "application/rdf+xml";
         final String contentType2 = "text/turtle";
         final String contentType3 = "application/ld+json";
@@ -159,7 +172,7 @@ public class FcrepoEndpointTest {
 
     @Test
     public void testPreferOmit() {
-        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
+        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext, testConfig);
         final String omit1 = "PreferContainment";
         final String omit2 = "http://www.w3.org/ns/ldp#PreferMembership";
         final String omit3 = "http://www.w3.org/ns/ldp#PreferMinimalContainer " +
@@ -175,7 +188,7 @@ public class FcrepoEndpointTest {
 
     @Test
     public void testPreferInclude() {
-        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
+        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext, testConfig);
         final String include1 = "PreferContainment";
         final String include2 = "http://www.w3.org/ns/ldp#PreferMembership";
         final String include3 = "http://www.w3.org/ns/ldp#PreferMinimalContainer " +
@@ -191,7 +204,7 @@ public class FcrepoEndpointTest {
 
     @Test
     public void testSecure() {
-        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
+        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext, testConfig);
         assertEquals(false, testEndpoint.getSecure());
         testEndpoint.setSecure(true);
         assertEquals(true, testEndpoint.getSecure());
@@ -199,7 +212,7 @@ public class FcrepoEndpointTest {
 
     @Test
     public void testSingleton() {
-        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext);
+        final FcrepoEndpoint testEndpoint = new FcrepoEndpoint(FCREPO_URI, FCREPO_PATH, mockContext, testConfig);
         assertEquals(true, testEndpoint.isSingleton());
     }
 

--- a/src/test/java/org/fcrepo/camel/FcrepoProducerTest.java
+++ b/src/test/java/org/fcrepo/camel/FcrepoProducerTest.java
@@ -56,7 +56,8 @@ public class FcrepoProducerTest {
     public void setUp() throws IOException {
         final FcrepoComponent mockComponent = mock(FcrepoComponent.class);
 
-        testEndpoint = new FcrepoEndpoint("fcrepo:localhost:8080", "/rest", mockComponent);
+        final FcrepoConfiguration testConfig = new FcrepoConfiguration();
+        testEndpoint = new FcrepoEndpoint("fcrepo:localhost:8080", "/rest", mockComponent, testConfig);
         testEndpoint.setBaseUrl("localhost:8080/rest");
         testExchange = new DefaultExchange(new DefaultCamelContext());
         testExchange.getIn().setBody(null);


### PR DESCRIPTION
https://jira.duraspace.org/browse/FCREPO-1296

While users can configure the fcrepo component via URI options, there are times when certain options apply to every use of the component. This PR adds component-wide configuration support via Spring/Blueprint for the `auth`* and `secure` options like so:

    <bean id="fcrepo" class="org.fcrepo.camel.FcrepoComponent">
      <property name="authUsername" value="${fcrepo.authUsername}"/>
      <property name="authPassword" value="${fcrepo.authPassword}"/>
    </bean>

Then, those options are automatically included in any `RouteBuilder`-based fcrepo endpoint.

This also adds a separate FcrepoConfiguration class, following the pattern of other camel components that support this type of component configuration.