### PR TITLE
ignore the target directories in examples/*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ velocity.log
 .classpath
 .project
 .settings/
+/examples/*/target/


### PR DESCRIPTION
This simply instructs git to ignore the `target/` directories in the `examples` directory