### PR TITLE
Rename dynamic build properties for clarity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -434,7 +434,7 @@
           </systemProperties>
           <scanIntervalSeconds>10</scanIntervalSeconds>
           <stopKey>STOP</stopKey>
-          <stopPort>${jetty.port.stop}</stopPort>
+          <stopPort>${jetty.dynamic.stop.port}</stopPort>
           <daemon>true</daemon>
         </configuration>
         <dependencies>
@@ -459,7 +459,7 @@
             </goals>
             <configuration>
               <httpConnector>
-                <port>${test.solr.port}</port>
+                <port>${solr.dynamic.test.port}</port>
               </httpConnector>
               <scanIntervalSeconds>0</scanIntervalSeconds>
               <daemon>true</daemon>
@@ -515,10 +515,10 @@
         <version>1.9.1</version>
         <configuration>
           <portNames>
-            <portName>test.port</portName>
-            <portName>test.fuseki.port</portName>
-            <portName>test.solr.port</portName>
-            <portName>jetty.port.stop</portName>
+            <portName>fcrepo.dynamic.test.port</portName>
+            <portName>fuseki.dynamic.test.port</portName>
+            <portName>solr.dynamic.test.port</portName>
+            <portName>jetty.dynamic.stop.port</portName>
           </portNames>
         </configuration>
         <executions>
@@ -555,9 +555,9 @@
         <configuration>
           <argLine>-XX:MaxPermSize=128m ${jacoco.agent.it.arg}</argLine>
           <systemPropertyVariables>
-            <test.port>${test.port}</test.port>
-            <test.fuseki.port>${test.fuseki.port}</test.fuseki.port>
-            <test.solr.port>${test.solr.port}</test.solr.port>
+            <fcrepo.dynamic.test.port>${fcrepo.dynamic.test.port}</fcrepo.dynamic.test.port>
+            <fuseki.dynamic.test.port>${fuseki.dynamic.test.port}</fuseki.dynamic.test.port>
+            <solr.dynamic.test.port>${solr.dynamic.test.port}</solr.dynamic.test.port>
           </systemPropertyVariables>
         </configuration>
         <executions>

--- a/src/test/java/org/fcrepo/camel/integration/FcrepoSolrIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FcrepoSolrIT.java
@@ -125,7 +125,7 @@ public class FcrepoSolrIT extends CamelTestSupport {
             public void configure() {
                 final String fcrepo_uri = FcrepoTestUtils.getFcrepoEndpointUri();
                 final String solr_uri = "http4://localhost:" + System.getProperty(
-                        "test.solr.port", "8983") + "/solr/testCore/update";
+                        "solr.dynamic.test.port", "8983") + "/solr/testCore/update";
 
                 from("direct:setup")
                     .to(fcrepo_uri);

--- a/src/test/java/org/fcrepo/camel/integration/FcrepoSparqlIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FcrepoSparqlIT.java
@@ -60,7 +60,7 @@ public class FcrepoSparqlIT extends CamelTestSupport {
     final private Logger logger = getLogger(FcrepoSparqlIT.class);
 
     private static final int FUSEKI_PORT = Integer.parseInt(System.getProperty(
-            "test.fuseki.port", "3030"));
+            "fuseki.dynamic.test.port", "3030"));
 
     private static EmbeddedFusekiServer server = null;
 
@@ -114,7 +114,7 @@ public class FcrepoSparqlIT extends CamelTestSupport {
                 "direct:setup", FcrepoTestUtils.getTurtleDocument(), headers, String.class);
 
         final String identifier = fullPath.replaceAll(FcrepoTestUtils.getFcrepoBaseUrl(), "");
-        final String base_url = "http://localhost:" + System.getProperty("test.port", "8080") + "/rest";
+        final String base_url = "http://localhost:" + System.getProperty("fcrepo.dynamic.test.port", "8080") + "/rest";
 
         // Test
         final Map<String, Object> testHeaders = new HashMap<String, Object>();
@@ -163,7 +163,7 @@ public class FcrepoSparqlIT extends CamelTestSupport {
                 "direct:setup", FcrepoTestUtils.getTurtleDocument(), headers, String.class);
 
         final String identifier = fullPath.replaceAll(FcrepoTestUtils.getFcrepoBaseUrl(), "");
-        final String base_url = "http://localhost:" + System.getProperty("test.port", "8080") + "/rest";
+        final String base_url = "http://localhost:" + System.getProperty("fcrepo.dynamic.test.port", "8080") + "/rest";
 
         // Test
         final Map<String, Object> testHeaders = new HashMap<String, Object>();
@@ -217,7 +217,7 @@ public class FcrepoSparqlIT extends CamelTestSupport {
                 "direct:setup", FcrepoTestUtils.getTurtleDocument(), headers, String.class);
 
         final String identifier = fullPath.replaceAll(FcrepoTestUtils.getFcrepoBaseUrl(), "");
-        final String base_url = "http://localhost:" + System.getProperty("test.port", "8080") + "/rest";
+        final String base_url = "http://localhost:" + System.getProperty("fcrepo.dynamic.test.port", "8080") + "/rest";
 
         // Test
         final Map<String, Object> testHeaders = new HashMap<String, Object>();
@@ -253,7 +253,7 @@ public class FcrepoSparqlIT extends CamelTestSupport {
             public void configure() throws IOException {
 
                 final String fcrepo_uri = FcrepoTestUtils.getFcrepoEndpointUri();
-                final String fuseki_url = "localhost:" + System.getProperty("test.fuseki.port", "3030");
+                final String fuseki_url = "localhost:" + System.getProperty("fuseki.dynamic.test.port", "3030");
                 final Processor sparqlInsert = new SparqlInsertProcessor();
                 final Namespaces ns = new Namespaces("rdf", RdfNamespaces.RDF);
                 ns.add("dc", "http://purl.org/dc/elements/1.1/");

--- a/src/test/java/org/fcrepo/camel/integration/FcrepoTestUtils.java
+++ b/src/test/java/org/fcrepo/camel/integration/FcrepoTestUtils.java
@@ -26,7 +26,7 @@ import static java.lang.System.getProperty;
 public final class FcrepoTestUtils {
 
     private static final int FCREPO_PORT = parseInt(getProperty(
-                "test.port", "8080"));
+                "fcrepo.dynamic.test.port", "8080"));
 
     /**
      * This is a utility class; the constructor is off-limits

--- a/src/test/resources/spring-test/test-container.xml
+++ b/src/test/resources/spring-test/test-container.xml
@@ -8,7 +8,7 @@
   <context:property-placeholder/>
 
   <bean id="containerWrapper" class="org.fcrepo.http.commons.test.util.ContainerWrapper" init-method="start" destroy-method="stop" >
-    <property name="port" value="${test.port:8080}"/>
+    <property name="port" value="${fcrepo.dynamic.test.port:8080}"/>
     <property name="configLocation" value="classpath:web.xml" />
   </bean>
 


### PR DESCRIPTION
The build-helper-maven-plugin is used to generate properties for dynamic
port configuration. This commit marks these properties with the word
`dynamic` to highlight that fact, e.g. `fcrepo.dynamic.test.port`.