### PR TITLE
add missing dependency; organize list of feature bundles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <!-- dependencies -->
     <camel.version>2.14.1</camel.version>
     <camel.version.range>[2.14,3)</camel.version.range>
-    <clerezza.ext.icu.version>0.6</clerezza.ext.icu.version>
+    <clerezza.ext.jena.version>2.11.1_1</clerezza.ext.jena.version>
     <clerezza.rdf.jena.serializer.version>0.11</clerezza.rdf.jena.serializer.version>
     <clerezza.rdf.jena.parser.version>0.12</clerezza.rdf.jena.parser.version>
     <clerezza.rdf.core.version>0.14</clerezza.rdf.core.version>
@@ -58,7 +58,7 @@
     <!-- osgi bundle transitive dependencies (for karaf provisioning) -->
     <clerezza.utils.version>0.2</clerezza.utils.version>
     <clerezza.ext.icu.version>0.6</clerezza.ext.icu.version>
-    <clerezza.ext.jena.version>2.11.1_1</clerezza.ext.jena.version>
+    <clerezza.ext.jena.iri.version>1.0.1_1</clerezza.ext.jena.iri.version>
     <clerezza.rdf.jena.facade.version>0.14</clerezza.rdf.jena.facade.version>
     <clerezza.rdf.jena.commons.version>0.7</clerezza.rdf.jena.commons.version>
     <commons.codec.version>1.9</commons.codec.version>
@@ -175,6 +175,12 @@
       <groupId>org.apache.clerezza</groupId>
       <artifactId>rdf.jena.serializer</artifactId>
       <version>${clerezza.rdf.jena.serializer.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.clerezza.ext</groupId>
+      <artifactId>org.apache.jena.jena-core</artifactId>
+      <version>${clerezza.ext.jena.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/resources/features.xml
+++ b/src/main/resources/features.xml
@@ -4,20 +4,22 @@
     <details>Installs the fcrepo-camel component</details>
     <bundle>mvn:org.fcrepo.camel/fcrepo-camel/${project.version}</bundle>
     <bundle dependency="true">mvn:commons-codec/commons-codec/${commons.codec.version}</bundle>
-    <bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons.lang3.version}</bundle>
-    <bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/${httpclient.version}</bundle>
-    <bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/${httpcore.version}</bundle>
     <bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
-    <bundle dependency="true">mvn:org.apache.clerezza/rdf.core/${clerezza.rdf.core.version}</bundle>
-    <bundle dependency="true">mvn:org.apache.clerezza/utils/${clerezza.utils.version}</bundle>
     <bundle dependency="true">mvn:org.apache.clerezza.ext/com.ibm.icu/${clerezza.ext.icu.version}</bundle>
-    <bundle dependency="true">mvn:org.wymiwyg/wymiwyg-commons-core/${wymiwyg.version}</bundle>
+    <bundle dependency="true">mvn:org.apache.clerezza.ext/org.apache.jena.jena-core/${clerezza.ext.jena.version}</bundle>
+    <bundle dependency="true">mvn:org.apache.clerezza.ext/org.apache.jena.jena-iri/${clerezza.ext.jena.iri.version}</bundle>
+    <bundle dependency="true">mvn:org.apache.clerezza.ext/org.apache.jena.jena-arq/${clerezza.ext.jena.version}</bundle>
+    <bundle dependency="true">mvn:org.apache.clerezza/rdf.core/${clerezza.rdf.core.version}</bundle>
     <bundle dependency="true">mvn:org.apache.clerezza/rdf.jena.serializer/${clerezza.rdf.jena.serializer.version}</bundle>
     <bundle dependency="true">mvn:org.apache.clerezza/rdf.jena.parser/${clerezza.rdf.jena.parser.version}</bundle>
-    <bundle dependency="true">mvn:org.apache.clerezza.ext/org.apache.jena.jena-core/${clerezza.ext.jena.version}</bundle>
     <bundle dependency="true">mvn:org.apache.clerezza/rdf.jena.facade/${clerezza.rdf.jena.facade.version}</bundle>
     <bundle dependency="true">mvn:org.apache.clerezza/rdf.jena.commons/${clerezza.rdf.jena.commons.version}</bundle>
+    <bundle dependency="true">mvn:org.apache.clerezza/utils/${clerezza.utils.version}</bundle>
+    <bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons.lang3.version}</bundle>
     <bundle dependency="true">mvn:org.apache.felix/org.osgi.compendium/${felix.osgi.version}</bundle>
+    <bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/${httpclient.version}</bundle>
+    <bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/${httpcore.version}</bundle>
+    <bundle dependency="true">mvn:org.wymiwyg/wymiwyg-commons-core/${wymiwyg.version}</bundle>
     <feature version="${camel.version.range}">camel</feature>
   </feature>
 </features>


### PR DESCRIPTION
See https://jira.duraspace.org/browse/FCREPO-1367

The `org.apache.jena.jena-core` artifact needed to be listed as a full dependency in maven;
The `clerezza.ext.icu.version` property was listed twice in maven -- that is cleaned up
The karaf feature file had no order to the dependency list -- it is now alphabetical
The following packages needed to be added to the features.xml file

    * mvn:org.apache.clerezza.ext/org.apache.jena.jena-core
    * mvn:org.apache.clerezza.ext/org.apache.jena.jena-iri
    * mvn:org.apache.clerezza.ext/org.apache.jena.jena-arq
