### PR TITLE
For https://jira.duraspace.org/browse/FCREPO-1598

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <commons.logging.version>1.1.3</commons.logging.version>
     <grizzly.version>2.3.18</grizzly.version>
     <guava.version>18.0</guava.version>
-    <httpclient.version>4.3.5</httpclient.version>
+    <httpclient.version>4.3.6</httpclient.version>
     <jena.fuseki.version>1.1.1</jena.fuseki.version>
     <jersey.version>2.15</jersey.version>
     <mockito.version>1.10.8</mockito.version>
@@ -63,7 +63,7 @@
     <clerezza.rdf.jena.commons.version>0.7</clerezza.rdf.jena.commons.version>
     <commons.codec.version>1.9</commons.codec.version>
     <felix.osgi.version>1.4.0</felix.osgi.version>
-    <httpcore.version>4.3.2</httpcore.version>
+    <httpcore.version>4.3.3</httpcore.version>
     <wymiwyg.version>0.7.6</wymiwyg.version>
     <!-- plugins -->
     <build.helper.plugin.version>1.9.1</build.helper.plugin.version>


### PR DESCRIPTION
Version bump on dependencies to get rid of Could not initialize class org.apache.http.conn.ssl.SSLConnectionSocketFactory exception when fcrepo component autoloads in OSGi