### PR TITLE
FCREPO-4091: Upgrade dependencies to latest and target JDK 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
       run: git config --global core.longpaths true
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Set up JDK 11
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: 11
+        java-version: 21
         distribution: temurin
     - name: Cache Maven packages
       uses: actions/cache@v4
@@ -55,10 +55,10 @@ jobs:
         run: git config --global core.longpaths true
       - name: Checkout fcrepo
         uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 21
           distribution: temurin
           server-id: central
           server-username: MAVEN_USERNAME

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ for use with [Apache Camel](https://camel.apache.org).
 
 [![Build Status](https://travis-ci.com/fcrepo-exts/fcrepo-camel.svg?branch=master)](https://travis-ci.com/fcrepo-exts/fcrepo-camel)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.fcrepo.camel/fcrepo-camel/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.fcrepo.camel/fcrepo-camel/)
+[![codecov](https://codecov.io/gh/fcrepo-exts/fcrepo-camel/branch/main/graph/badge.svg)](https://codecov.io/gh/fcrepo-exts/fcrepo-camel)
 
 URI format
 ----------

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+# Codecov configuration for fcrepo-camel.
+# Coverage is produced by the jacoco-maven-plugin (merged unit + integration
+# report at target/site/jacoco/jacoco.xml) and uploaded from CI.
+coverage:
+  precision: 2
+  round: down
+  range: "90...100"
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 1%
+    patch:
+      default:
+        target: 90%
+        threshold: 1%
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: false

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <artifactId>fcrepo-camel</artifactId>
   <packaging>jar</packaging>
 
-  <version>6.1.0-SNAPSHOT</version>
+  <version>7.0.0-SNAPSHOT</version>
 
   <name>Fcrepo Camel Component</name>
   <description>Camel Component for interacting with a Fedora Repository</description>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <logback.version>1.2.13</logback.version>
 
     <failsafe.plugin.version>3.5.5</failsafe.plugin.version>
+    <jacoco.plugin.version>0.8.12</jacoco.plugin.version>
     <central-publishing-plugin.version>0.9.0</central-publishing-plugin.version>
 
     <!-- plugins -->
@@ -313,11 +314,20 @@
 
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- @{argLine} injects the JaCoCo unit-test agent set by the prepare-agent
+            goal. Without this, the parent pom's hardcoded argLine would suppress the
+            agent and unit-test coverage would not be recorded. -->
+          <argLine>@{argLine} -Xms512m -Xmx1024m</argLine>
+        </configuration>
       </plugin>
-      
+
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
+        <!-- Pin to a version that can instrument Java 17+ bytecode so coverage
+          works on JDKs newer than the CI baseline (JDK 11). -->
+        <version>${jacoco.plugin.version}</version>
         <executions>
           <execution>
             <id>prepare-unit</id>

--- a/pom.xml
+++ b/pom.xml
@@ -36,23 +36,27 @@
     <!-- https://github.com/github/maven-plugins/blob/master/README.md -->
     <github.global.server>github</github.global.server>
 
+    <!-- Target JDK 21 (overrides fcrepo-parent's Java 11 baseline) -->
+    <project.java.source>21</project.java.source>
+
     <!-- dependencies -->
-    <camel.version>3.22.4</camel.version>
-    <commons.io.version>2.21.0</commons.io.version>
+    <camel.version>4.20.0</camel.version>
+    <commons.io.version>2.22.0</commons.io.version>
     <commons.lang3.version>3.20.0</commons.lang3.version>
-    <jena.version>4.10.0</jena.version>
-    <junit.version>5.10.2</junit.version>
-    <mockito.version>5.11.0</mockito.version>
-    <slf4j.version>1.7.36</slf4j.version>
-    <spring.version>5.3.39</spring.version>
+    <jena.version>6.1.0</jena.version>
+    <junit.version>6.1.1</junit.version>
+    <mockito.version>5.23.0</mockito.version>
+    <slf4j.version>2.0.17</slf4j.version>
+    <spring.version>7.0.8</spring.version>
     <fcrepo.version>6.5.1</fcrepo.version>
     <fcrepo-java-client.version>6.2.0</fcrepo-java-client.version>
-    <jaxb.core.version>2.3.0.1</jaxb.core.version>
-    <javaee-api.version>8.0.1</javaee-api.version>
-    <javaee.xml.version>2.3.1</javaee.xml.version>
+    <jakarta.xml.bind.version>4.0.2</jakarta.xml.bind.version>
+    <jaxb.runtime.version>4.0.5</jaxb.runtime.version>
+    <pooled.jms.version>3.2.2</pooled.jms.version>
 
-    <logback.version>1.2.13</logback.version>
+    <logback.version>1.5.37</logback.version>
 
+    <surefire.plugin.version>3.5.5</surefire.plugin.version>
     <failsafe.plugin.version>3.5.5</failsafe.plugin.version>
     <jacoco.plugin.version>0.8.12</jacoco.plugin.version>
     <central-publishing-plugin.version>0.9.0</central-publishing-plugin.version>
@@ -138,22 +142,19 @@
       <version>${fcrepo-java-client.version}</version>
     </dependency>
 
+    <!-- Jakarta XML Binding (JAXB) API + Glassfish runtime. Replaces the legacy
+      javax.xml.bind/com.sun JAXB shims now that the stack (Camel 4, Spring 7,
+      Jena 6) is Jakarta EE based. jaxb-runtime pulls in Jakarta Activation. -->
     <dependency>
-      <groupId>com.sun.activation</groupId>
-      <artifactId>javax.activation</artifactId>
-      <version>1.2.0</version>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>${jakarta.xml.bind.version}</version>
     </dependency>
-
-   <dependency>
-     <groupId>javax.xml.bind</groupId>
-     <artifactId>jaxb-api</artifactId>
-     <version>${javaee.xml.version}</version>
-   </dependency>
-   <dependency>
-     <groupId>com.sun.xml.bind</groupId>
-     <artifactId>jaxb-core</artifactId>
-     <version>${jaxb.core.version}</version>
-   </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>${jaxb.runtime.version}</version>
+    </dependency>
 
     <!-- logging -->
     <dependency>
@@ -212,6 +213,15 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-activemq</artifactId>
       <version>${camel.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Camel 4's ActiveMQ component pools connections via messaginghub pooled-jms,
+      which is no longer pulled in transitively. Version aligned with camel-parent. -->
+    <dependency>
+      <groupId>org.messaginghub</groupId>
+      <artifactId>pooled-jms</artifactId>
+      <version>${pooled.jms.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -314,6 +324,9 @@
 
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <!-- Override fcrepo-parent's surefire 2.x, whose JUnit Platform provider
+          is incompatible with JUnit 6 (JUnit Platform 6). -->
+        <version>${surefire.plugin.version}</version>
         <configuration>
           <!-- @{argLine} injects the JaCoCo unit-test agent set by the prepare-agent
             goal. Without this, the parent pom's hardcoded argLine would suppress the
@@ -359,6 +372,10 @@
 
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Override fcrepo-parent's hardcoded release 11 to target JDK 21 -->
+          <release>${project.java.source}</release>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/src/main/java/org/fcrepo/camel/FcrepoHeaders.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoHeaders.java
@@ -30,6 +30,13 @@ public final class FcrepoHeaders {
 
     public static final String FCREPO_EVENT_ID = "CamelFcrepoEventId";
 
+    /**
+     * The requested response content type. Replaces the {@code ACCEPT_CONTENT_TYPE}
+     * constant removed from {@code org.apache.camel.Exchange} in Camel 4, keeping the
+     * original {@code "CamelAcceptContentType"} value so existing routes continue to work.
+     */
+    public static final String ACCEPT_CONTENT_TYPE = "CamelAcceptContentType";
+
     private FcrepoHeaders() {
         // prevent instantiation
     }

--- a/src/main/java/org/fcrepo/camel/FcrepoProducer.java
+++ b/src/main/java/org/fcrepo/camel/FcrepoProducer.java
@@ -11,13 +11,13 @@ import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.stream.Collectors.toList;
-import static org.apache.camel.Exchange.ACCEPT_CONTENT_TYPE;
 import static org.apache.camel.Exchange.CONTENT_TYPE;
 import static org.apache.camel.Exchange.HTTP_METHOD;
 import static org.apache.camel.Exchange.HTTP_RESPONSE_CODE;
 import static org.apache.camel.Exchange.DISABLE_HTTP_STREAM_CACHE;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.fcrepo.camel.FcrepoConstants.FIXITY;
+import static org.fcrepo.camel.FcrepoHeaders.ACCEPT_CONTENT_TYPE;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_BASE_URL;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_IDENTIFIER;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_PREFER;
@@ -285,7 +285,7 @@ public class FcrepoProducer extends DefaultProducer {
     /**
      * Given an exchange, extract the value for use with an Accept header. The order of preference is:
      * 1) whether an accept value is set on the endpoint 2) a value set on
-     * the Exchange.ACCEPT_CONTENT_TYPE header 3) a value set on an "Accept" header
+     * the FcrepoHeaders.ACCEPT_CONTENT_TYPE header 3) a value set on an "Accept" header
      * 4) the endpoint DEFAULT_CONTENT_TYPE (i.e. application/rdf+xml)
      *
      * @param exchange the incoming message exchange

--- a/src/test/java/org/fcrepo/camel/ActivityStreamTermsTest.java
+++ b/src/test/java/org/fcrepo/camel/ActivityStreamTermsTest.java
@@ -1,0 +1,37 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.camel;
+
+import static java.net.URI.create;
+import static org.fcrepo.camel.processor.ActivityStreamTerms.ACTIVITY_STREAMS_BASEURI;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.fcrepo.camel.processor.ActivityStreamTerms;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ActivityStreamTerms}.
+ *
+ * @author Dan Field
+ */
+public class ActivityStreamTermsTest {
+
+    @Test
+    public void testAsUri() {
+        assertEquals(create(ACTIVITY_STREAMS_BASEURI + "Create"), ActivityStreamTerms.Create.asUri());
+        assertEquals(create(ACTIVITY_STREAMS_BASEURI + "Update"), ActivityStreamTerms.Update.asUri());
+    }
+
+    @Test
+    public void testExpandKnownTerm() {
+        assertEquals(ACTIVITY_STREAMS_BASEURI + "Delete", ActivityStreamTerms.expand("Delete"));
+    }
+
+    @Test
+    public void testExpandUnknownTermReturnsInput() {
+        assertEquals("http://example.org/NotATerm", ActivityStreamTerms.expand("http://example.org/NotATerm"));
+    }
+}

--- a/src/test/java/org/fcrepo/camel/EventProcessorDirectTest.java
+++ b/src/test/java/org/fcrepo/camel/EventProcessorDirectTest.java
@@ -1,0 +1,212 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.camel;
+
+import static java.util.Arrays.asList;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_AGENT;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_DATE_TIME;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_EVENT_ID;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_EVENT_TYPE;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_RESOURCE_TYPE;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.fcrepo.camel.processor.EventProcessor;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the EventProcessor with bodies that use the JSON-LD compact ({@code @id}/{@code @type})
+ * keywords, with a single (non-array) actor, and with pre-parsed Map bodies. These paths are not
+ * exercised by the resource-driven {@link EventProcessorTest}.
+ *
+ * @author Dan Field
+ */
+public class EventProcessorDirectTest {
+
+    private final EventProcessor processor = new EventProcessor();
+
+    private Exchange newExchange(final Object body) {
+        final Exchange exchange = new DefaultExchange(new DefaultCamelContext());
+        exchange.getIn().setBody(body);
+        return exchange;
+    }
+
+    @Test
+    public void testJsonWithKeywordsAndSingleActor() throws Exception {
+        final String json = "{" +
+                "\"@id\": \"urn:uuid:event-1\"," +
+                "\"type\": [\"Create\"]," +
+                "\"published\": \"2020-01-01T00:00:00Z\"," +
+                "\"actor\": {\"name\": \"Some Agent\", \"id\": \"info:fedora/local-user#someAdmin\"}," +
+                "\"object\": {" +
+                    "\"@id\": \"http://localhost:8080/rest/path\"," +
+                    "\"@type\": [\"http://www.w3.org/ns/ldp#Container\"]" +
+                "}" +
+                "}";
+
+        final Exchange exchange = newExchange(json);
+        processor.process(exchange);
+
+        assertEquals("urn:uuid:event-1", exchange.getIn().getHeader(FCREPO_EVENT_ID));
+        assertEquals("2020-01-01T00:00:00Z", exchange.getIn().getHeader(FCREPO_DATE_TIME));
+        assertEquals("http://localhost:8080/rest/path", exchange.getIn().getHeader(FCREPO_URI));
+        assertEquals(asList("https://www.w3.org/ns/activitystreams#Create"),
+                exchange.getIn().getHeader(FCREPO_EVENT_TYPE));
+        assertEquals(asList("http://www.w3.org/ns/ldp#Container"),
+                exchange.getIn().getHeader(FCREPO_RESOURCE_TYPE));
+        // id is applied after name for a single actor object
+        assertEquals(asList("info:fedora/local-user#someAdmin"), exchange.getIn().getHeader(FCREPO_AGENT));
+    }
+
+    @Test
+    public void testJsonSingleActorNameOnly() throws Exception {
+        final String json = "{" +
+                "\"id\": \"urn:uuid:event-2\"," +
+                "\"type\": [\"Update\"]," +
+                "\"actor\": {\"name\": \"Only Name\"}," +
+                "\"object\": {\"id\": \"http://localhost:8080/rest/other\"}" +
+                "}";
+
+        final Exchange exchange = newExchange(json);
+        processor.process(exchange);
+
+        assertEquals("urn:uuid:event-2", exchange.getIn().getHeader(FCREPO_EVENT_ID));
+        assertEquals(asList("Only Name"), exchange.getIn().getHeader(FCREPO_AGENT));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testMapBodyWithKeywords() throws Exception {
+        final Map<String, Object> object = new HashMap<>();
+        object.put("type", asList("http://www.w3.org/ns/ldp#Container"));
+        object.put("id", "http://localhost:8080/rest/mapped");
+
+        final Map<String, String> actorWithName = new HashMap<>();
+        actorWithName.put("name", "Agent Name");
+        final Map<String, String> actorWithId = new HashMap<>();
+        actorWithId.put("id", "info:fedora/local-user#mapAdmin");
+
+        final Map<String, Object> body = new HashMap<>();
+        body.put("@id", "urn:uuid:event-3");
+        body.put("@type", asList("Create"));
+        body.put("published", "2021-02-03T00:00:00Z");
+        body.put("object", object);
+        body.put("actor", asList(actorWithName, actorWithId));
+
+        final Exchange exchange = newExchange(body);
+        processor.process(exchange);
+
+        assertEquals("urn:uuid:event-3", exchange.getIn().getHeader(FCREPO_EVENT_ID));
+        assertEquals("2021-02-03T00:00:00Z", exchange.getIn().getHeader(FCREPO_DATE_TIME));
+        assertEquals("http://localhost:8080/rest/mapped", exchange.getIn().getHeader(FCREPO_URI));
+        assertEquals(asList("https://www.w3.org/ns/activitystreams#Create"),
+                exchange.getIn().getHeader(FCREPO_EVENT_TYPE));
+        final List<String> agents = exchange.getIn().getHeader(FCREPO_AGENT, List.class);
+        assertEquals(asList("Agent Name", "info:fedora/local-user#mapAdmin"), agents);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testMapBodyWithLowercaseKeys() throws Exception {
+        final Map<String, Object> body = new HashMap<>();
+        body.put("id", "urn:uuid:event-4");
+        body.put("type", asList("Update"));
+
+        final Exchange exchange = newExchange(body);
+        processor.process(exchange);
+
+        assertEquals("urn:uuid:event-4", exchange.getIn().getHeader(FCREPO_EVENT_ID));
+        assertEquals(asList("https://www.w3.org/ns/activitystreams#Update"),
+                exchange.getIn().getHeader(FCREPO_EVENT_TYPE));
+    }
+
+    @Test
+    public void testNullBody() throws Exception {
+        final Exchange exchange = newExchange(null);
+        processor.process(exchange);
+
+        assertNull(exchange.getIn().getHeader(FCREPO_EVENT_ID));
+        assertNull(exchange.getIn().getHeader(FCREPO_URI));
+    }
+
+    @Test
+    public void testUnsupportedBodyType() throws Exception {
+        // a body that is neither a Map, a String, nor an InputStream is ignored
+        final Exchange exchange = newExchange(Integer.valueOf(42));
+        processor.process(exchange);
+
+        assertNull(exchange.getIn().getHeader(FCREPO_EVENT_ID));
+        assertNull(exchange.getIn().getHeader(FCREPO_URI));
+    }
+
+    @Test
+    public void testJsonMinimalNoObjectNoActor() throws Exception {
+        final Exchange exchange = newExchange("{\"@id\": \"urn:uuid:event-minimal\"}");
+        processor.process(exchange);
+
+        assertEquals("urn:uuid:event-minimal", exchange.getIn().getHeader(FCREPO_EVENT_ID));
+        assertNull(exchange.getIn().getHeader(FCREPO_URI));
+        assertNull(exchange.getIn().getHeader(FCREPO_AGENT));
+    }
+
+    @Test
+    public void testJsonEmptyTypeArrayIsDropped() throws Exception {
+        final Exchange exchange = newExchange("{\"@id\": \"urn:uuid:event-empty\", \"type\": []}");
+        processor.process(exchange);
+
+        assertEquals("urn:uuid:event-empty", exchange.getIn().getHeader(FCREPO_EVENT_ID));
+        // an empty value list is filtered out and never set as a header
+        assertNull(exchange.getIn().getHeader(FCREPO_EVENT_TYPE));
+    }
+
+    @Test
+    public void testJsonWithNonTextualValues() throws Exception {
+        // mixes non-textual entries that should be skipped: a numeric type element, a numeric
+        // actor name (falls through to the id), and an object whose @id is itself an object.
+        final String json = "{" +
+                "\"@id\": \"urn:uuid:event-mixed\"," +
+                "\"type\": [\"Create\", 5]," +
+                "\"actor\": {\"name\": 42, \"id\": \"info:fedora/local-user#mixedAdmin\"}," +
+                "\"object\": {\"@id\": {\"nested\": \"x\"}, \"@type\": [\"http://example.org/T\"]}" +
+                "}";
+
+        final Exchange exchange = newExchange(json);
+        processor.process(exchange);
+
+        assertEquals(asList("https://www.w3.org/ns/activitystreams#Create"),
+                exchange.getIn().getHeader(FCREPO_EVENT_TYPE));
+        assertEquals(asList("info:fedora/local-user#mixedAdmin"), exchange.getIn().getHeader(FCREPO_AGENT));
+        assertEquals(asList("http://example.org/T"), exchange.getIn().getHeader(FCREPO_RESOURCE_TYPE));
+        // the non-textual @id is skipped, so no resource URI is set
+        assertNull(exchange.getIn().getHeader(FCREPO_URI));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testMapBodyObjectWithoutType() throws Exception {
+        final Map<String, Object> object = new HashMap<>();
+        object.put("id", "http://localhost:8080/rest/notype");
+
+        final Map<String, Object> body = new HashMap<>();
+        body.put("id", "urn:uuid:event-5");
+        body.put("object", object);
+
+        final Exchange exchange = newExchange(body);
+        processor.process(exchange);
+
+        assertEquals("urn:uuid:event-5", exchange.getIn().getHeader(FCREPO_EVENT_ID));
+        assertEquals("http://localhost:8080/rest/notype", exchange.getIn().getHeader(FCREPO_URI));
+        assertNull(exchange.getIn().getHeader(FCREPO_RESOURCE_TYPE));
+    }
+}

--- a/src/test/java/org/fcrepo/camel/EventProcessorTest.java
+++ b/src/test/java/org/fcrepo/camel/EventProcessorTest.java
@@ -33,10 +33,10 @@ import org.junit.jupiter.api.Test;
  */
 public class EventProcessorTest extends CamelTestSupport {
 
-    @EndpointInject(uri = "mock:result")
+    @EndpointInject("mock:result")
     protected MockEndpoint resultEndpoint;
 
-    @Produce(uri = "direct:start")
+    @Produce("direct:start")
     protected ProducerTemplate template;
 
     @Test

--- a/src/test/java/org/fcrepo/camel/FcrepoPreferTest.java
+++ b/src/test/java/org/fcrepo/camel/FcrepoPreferTest.java
@@ -67,4 +67,36 @@ public class FcrepoPreferTest {
         assertTrue(prefer.getOmit().contains(create(containment)));
         assertEquals(emptyList(), prefer.getInclude());
     }
+
+    @Test
+    public void testPreferMinimal() {
+        final FcrepoPrefer prefer = new FcrepoPrefer("return=minimal");
+        assertTrue(prefer.isMinimal());
+        assertFalse(prefer.isRepresentation());
+        assertEquals(emptyList(), prefer.getInclude());
+        assertEquals(emptyList(), prefer.getOmit());
+    }
+
+    @Test
+    public void testPreferNoReturnType() {
+        final FcrepoPrefer prefer = new FcrepoPrefer("include=\"" + embed + "\"");
+        assertFalse(prefer.isMinimal());
+        assertFalse(prefer.isRepresentation());
+        assertEquals(singletonList(create(embed)), prefer.getInclude());
+        assertEquals(emptyList(), prefer.getOmit());
+    }
+
+    @Test
+    public void testPreferNull() {
+        final FcrepoPrefer prefer = new FcrepoPrefer(null);
+        assertFalse(prefer.isMinimal());
+        assertFalse(prefer.isRepresentation());
+    }
+
+    @Test
+    public void testPreferEmptyValue() {
+        final FcrepoPrefer prefer = new FcrepoPrefer("return=representation; include=\"  \"");
+        assertTrue(prefer.isRepresentation());
+        assertEquals(emptyList(), prefer.getInclude());
+    }
 }

--- a/src/test/java/org/fcrepo/camel/FcrepoProducerTest.java
+++ b/src/test/java/org/fcrepo/camel/FcrepoProducerTest.java
@@ -14,6 +14,7 @@ import static org.apache.camel.Exchange.CONTENT_TYPE;
 import static org.apache.camel.Exchange.DISABLE_HTTP_STREAM_CACHE;
 import static org.apache.camel.Exchange.HTTP_METHOD;
 import static org.apache.camel.Exchange.HTTP_RESPONSE_CODE;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_BASE_URL;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_IDENTIFIER;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_PREFER;
 import static org.fcrepo.camel.FcrepoProducer.PREFER_PROPERTIES;
@@ -199,6 +200,74 @@ public class FcrepoProducerTest {
 
         assertEquals(testExchange.getIn().getBody(String.class), TestUtils.rdfTriples);
         assertEquals(testExchange.getIn().getHeader(CONTENT_TYPE, String.class), N_TRIPLES);
+    }
+
+    @Test
+    public void testGetPreferMinimalHeaderProducer() throws Exception {
+        final URI uri = create(TestUtils.baseUrl);
+        final ByteArrayInputStream body = new ByteArrayInputStream(TestUtils.rdfTriples.getBytes());
+        final FcrepoResponse headResponse = new FcrepoResponse(uri, 200, emptyMap(), null);
+        final FcrepoResponse getResponse = new FcrepoResponse(uri, 200,
+                singletonMap(CONTENT_TYPE, singletonList(N_TRIPLES)), body);
+
+        init();
+
+        testExchange.getIn().setHeader(FCREPO_IDENTIFIER, "/foo");
+        testExchange.getIn().setHeader(FCREPO_PREFER, "return=minimal");
+
+        when(mockHeadBuilder.perform()).thenReturn(headResponse);
+        when(mockGetBuilder.perform()).thenReturn(getResponse);
+
+        testProducer.process(testExchange);
+
+        assertEquals(testExchange.getIn().getBody(String.class), TestUtils.rdfTriples);
+        assertEquals(testExchange.getIn().getHeader(CONTENT_TYPE, String.class), N_TRIPLES);
+    }
+
+    @Test
+    public void testGetPreferOtherHeaderProducer() throws Exception {
+        final URI uri = create(TestUtils.baseUrl);
+        final ByteArrayInputStream body = new ByteArrayInputStream(TestUtils.rdfTriples.getBytes());
+        final FcrepoResponse headResponse = new FcrepoResponse(uri, 200, emptyMap(), null);
+        final FcrepoResponse getResponse = new FcrepoResponse(uri, 200,
+                singletonMap(CONTENT_TYPE, singletonList(N_TRIPLES)), body);
+
+        init();
+
+        testExchange.getIn().setHeader(FCREPO_IDENTIFIER, "/foo");
+        // a Prefer header that is neither minimal nor a representation request
+        testExchange.getIn().setHeader(FCREPO_PREFER, "handling=lenient");
+
+        when(mockHeadBuilder.perform()).thenReturn(headResponse);
+        when(mockGetBuilder.perform()).thenReturn(getResponse);
+
+        testProducer.process(testExchange);
+
+        assertEquals(testExchange.getIn().getBody(String.class), TestUtils.rdfTriples);
+        assertEquals(testExchange.getIn().getHeader(CONTENT_TYPE, String.class), N_TRIPLES);
+    }
+
+    @Test
+    public void testGetWithBaseUrlHeaderProducer() throws Exception {
+        final URI uri = create(TestUtils.baseUrl);
+        final ByteArrayInputStream body = new ByteArrayInputStream(TestUtils.rdfXml.getBytes());
+        final FcrepoResponse headResponse = new FcrepoResponse(uri, 200, emptyMap(), null);
+        final FcrepoResponse getResponse = new FcrepoResponse(uri, 200,
+                singletonMap(CONTENT_TYPE, singletonList(TestUtils.RDF_XML)), body);
+
+        init();
+
+        // supply the base url via a header rather than the endpoint configuration
+        testExchange.getIn().setHeader(FCREPO_BASE_URL, "http://localhost:8080/rest");
+        testExchange.getIn().setHeader(FCREPO_IDENTIFIER, "/foo");
+
+        when(mockHeadBuilder.perform()).thenReturn(headResponse);
+        when(mockGetBuilder.perform()).thenReturn(getResponse);
+
+        testProducer.process(testExchange);
+
+        assertEquals(testExchange.getIn().getBody(String.class), TestUtils.rdfXml);
+        assertEquals(testExchange.getIn().getHeader(CONTENT_TYPE, String.class), TestUtils.RDF_XML);
     }
 
     @Test

--- a/src/test/java/org/fcrepo/camel/FcrepoProducerTest.java
+++ b/src/test/java/org/fcrepo/camel/FcrepoProducerTest.java
@@ -9,7 +9,7 @@ import static java.net.URI.create;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static org.apache.camel.Exchange.ACCEPT_CONTENT_TYPE;
+import static org.fcrepo.camel.FcrepoHeaders.ACCEPT_CONTENT_TYPE;
 import static org.apache.camel.Exchange.CONTENT_TYPE;
 import static org.apache.camel.Exchange.DISABLE_HTTP_STREAM_CACHE;
 import static org.apache.camel.Exchange.HTTP_METHOD;
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.Exchange;
-import org.apache.camel.ExtendedExchange;
 import org.apache.camel.converter.stream.InputStreamCache;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.engine.DefaultUnitOfWork;
@@ -716,7 +715,7 @@ public class FcrepoProducerTest {
         uow.beginTransactedBy((Object)tx);
 
         testExchange.getIn().setHeader(FCREPO_IDENTIFIER, path);
-        testExchange.adapt(ExtendedExchange.class).setUnitOfWork(uow);
+        testExchange.getExchangeExtension().setUnitOfWork(uow);
 
         when(mockPostBuilder2.perform()).thenReturn(
                 new FcrepoResponse(beginUri, 201, singletonMap("Location", singletonList(baseUrl + "/" + tx)), null));
@@ -741,7 +740,7 @@ public class FcrepoProducerTest {
         testExchange.getIn().setHeader(HTTP_METHOD, "GET");
         testExchange.getIn().setHeader(ACCEPT_CONTENT_TYPE, N_TRIPLES);
         testExchange.getIn().setHeader(FCREPO_IDENTIFIER, path2);
-        testExchange.adapt(ExtendedExchange.class).setUnitOfWork(uow);
+        testExchange.getExchangeExtension().setUnitOfWork(uow);
         testProducer.process(testExchange);
         assertEquals(status, testExchange.getIn().getHeader(HTTP_RESPONSE_CODE));
         assertEquals(N_TRIPLES, testExchange.getIn().getHeader(CONTENT_TYPE, String.class));
@@ -775,7 +774,7 @@ public class FcrepoProducerTest {
         testExchange.getIn().setHeader(FCREPO_IDENTIFIER, path);
         testExchange.getIn().setHeader(CONTENT_TYPE, TestUtils.TEXT_PLAIN);
         testExchange.getIn().setBody(new ByteArrayInputStream("Test".getBytes()));
-        testExchange.adapt(ExtendedExchange.class).setUnitOfWork(uow);
+        testExchange.getExchangeExtension().setUnitOfWork(uow);
 
         when(mockClient2.post(eq(beginUri))).thenReturn(mockPostBuilder2);
         when(mockClient2.post(eq(commitUri))).thenReturn(mockPostBuilder3);
@@ -801,7 +800,7 @@ public class FcrepoProducerTest {
         testExchange.getIn().setHeader(HTTP_METHOD, "GET");
         testExchange.getIn().setHeader(ACCEPT_CONTENT_TYPE, N_TRIPLES);
         testExchange.getIn().setHeader(FCREPO_IDENTIFIER, path2);
-        testExchange.adapt(ExtendedExchange.class).setUnitOfWork(uow);
+        testExchange.getExchangeExtension().setUnitOfWork(uow);
         assertThrows(RuntimeException.class, () -> testProducer.process(testExchange));
     }
 

--- a/src/test/java/org/fcrepo/camel/ProcessorUtilsSubjectTest.java
+++ b/src/test/java/org/fcrepo/camel/ProcessorUtilsSubjectTest.java
@@ -1,0 +1,60 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.camel;
+
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_BASE_URL;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_IDENTIFIER;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
+import static org.fcrepo.camel.processor.ProcessorUtils.getSubjectUri;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.NoSuchHeaderException;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link org.fcrepo.camel.processor.ProcessorUtils#getSubjectUri}.
+ *
+ * @author Dan Field
+ */
+public class ProcessorUtilsSubjectTest {
+
+    private Exchange newExchange() {
+        return new DefaultExchange(new DefaultCamelContext());
+    }
+
+    @Test
+    public void testSubjectFromUriHeader() throws NoSuchHeaderException {
+        final Exchange exchange = newExchange();
+        exchange.getIn().setHeader(FCREPO_URI, "http://localhost:8080/rest/foo");
+        assertEquals("http://localhost:8080/rest/foo", getSubjectUri(exchange));
+    }
+
+    @Test
+    public void testSubjectFromBaseAndIdentifier() throws NoSuchHeaderException {
+        final Exchange exchange = newExchange();
+        exchange.getIn().setHeader(FCREPO_BASE_URL, "http://localhost:8080/rest");
+        exchange.getIn().setHeader(FCREPO_IDENTIFIER, "/foo");
+        assertEquals("http://localhost:8080/rest/foo", getSubjectUri(exchange));
+    }
+
+    @Test
+    public void testSubjectTrimsTrailingSlashOnBase() throws NoSuchHeaderException {
+        final Exchange exchange = newExchange();
+        exchange.getIn().setHeader(FCREPO_BASE_URL, "http://localhost:8080/rest/");
+        exchange.getIn().setHeader(FCREPO_IDENTIFIER, "/foo");
+        assertEquals("http://localhost:8080/rest/foo", getSubjectUri(exchange));
+    }
+
+    @Test
+    public void testSubjectMissingBaseUrlThrows() {
+        final Exchange exchange = newExchange();
+        assertThrows(NoSuchHeaderException.class, () -> getSubjectUri(exchange));
+    }
+}

--- a/src/test/java/org/fcrepo/camel/integration/FcrepoComponentConfigurationIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FcrepoComponentConfigurationIT.java
@@ -16,7 +16,6 @@ import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.jena.vocabulary.RDF;
 import org.fcrepo.camel.FcrepoComponent;
 import org.fcrepo.camel.FcrepoHeaders;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -55,11 +54,6 @@ public class FcrepoComponentConfigurationIT extends CamelTestSupport {
 
     @Produce("direct:filter")
     protected ProducerTemplate template;
-
-    @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
-    }
 
     @Test
     public void testGetContainer() throws InterruptedException {

--- a/src/test/java/org/fcrepo/camel/integration/FcrepoContentTypeEndpointIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FcrepoContentTypeEndpointIT.java
@@ -13,7 +13,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 
-import static org.apache.camel.Exchange.ACCEPT_CONTENT_TYPE;
+import static org.fcrepo.camel.FcrepoHeaders.ACCEPT_CONTENT_TYPE;
 import static org.fcrepo.camel.integration.FcrepoTestUtils.getFcrepoEndpointUri;
 
 /**

--- a/src/test/java/org/fcrepo/camel/integration/FcrepoContentTypeHeaderIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FcrepoContentTypeHeaderIT.java
@@ -6,7 +6,6 @@
 package org.fcrepo.camel.integration;
 
 import org.apache.camel.EndpointInject;
-import org.apache.camel.Exchange;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
@@ -14,6 +13,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.Test;
 
+import static org.fcrepo.camel.FcrepoHeaders.ACCEPT_CONTENT_TYPE;
 import static org.fcrepo.camel.FcrepoProducer.DEFAULT_CONTENT_TYPE;
 
 /**
@@ -36,7 +36,7 @@ public class FcrepoContentTypeHeaderIT extends CamelTestSupport {
         resultEndpoint.expectedMessageCount(2);
 
         template.sendBodyAndHeader(null, "Accept", "application/ld+json");
-        template.sendBodyAndHeader(null, Exchange.ACCEPT_CONTENT_TYPE, "application/ld+json");
+        template.sendBodyAndHeader(null, ACCEPT_CONTENT_TYPE, "application/ld+json");
 
         resultEndpoint.assertIsSatisfied();
     }
@@ -47,7 +47,7 @@ public class FcrepoContentTypeHeaderIT extends CamelTestSupport {
         resultEndpoint.expectedMessageCount(2);
 
         template.sendBodyAndHeader(null, "Accept", "application/rdf+xml");
-        template.sendBodyAndHeader(null, Exchange.ACCEPT_CONTENT_TYPE, "application/rdf+xml");
+        template.sendBodyAndHeader(null, ACCEPT_CONTENT_TYPE, "application/rdf+xml");
 
         resultEndpoint.assertIsSatisfied();
     }
@@ -58,7 +58,7 @@ public class FcrepoContentTypeHeaderIT extends CamelTestSupport {
         resultEndpoint.expectedMessageCount(2);
 
         template.sendBodyAndHeader(null, "Accept", "application/n-triples");
-        template.sendBodyAndHeader(null, Exchange.ACCEPT_CONTENT_TYPE, "application/n-triples");
+        template.sendBodyAndHeader(null, ACCEPT_CONTENT_TYPE, "application/n-triples");
 
         resultEndpoint.assertIsSatisfied();
     }
@@ -70,7 +70,7 @@ public class FcrepoContentTypeHeaderIT extends CamelTestSupport {
         resultEndpoint.expectedMessageCount(2);
 
         template.sendBodyAndHeader(null, "Accept", "text/turtle");
-        template.sendBodyAndHeader(null, Exchange.ACCEPT_CONTENT_TYPE, "text/turtle");
+        template.sendBodyAndHeader(null, ACCEPT_CONTENT_TYPE, "text/turtle");
 
         resultEndpoint.assertIsSatisfied();
     }
@@ -82,7 +82,7 @@ public class FcrepoContentTypeHeaderIT extends CamelTestSupport {
         resultEndpoint.expectedMessageCount(2);
 
         template.sendBodyAndHeader(null, "Accept", "text/rdf+n3");
-        template.sendBodyAndHeader(null, Exchange.ACCEPT_CONTENT_TYPE, "text/rdf+n3");
+        template.sendBodyAndHeader(null, ACCEPT_CONTENT_TYPE, "text/rdf+n3");
 
         resultEndpoint.assertIsSatisfied();
     }

--- a/src/test/java/org/fcrepo/camel/integration/FcrepoPutIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FcrepoPutIT.java
@@ -15,7 +15,6 @@ import org.apache.camel.support.builder.Namespaces;
 import org.apache.camel.test.junit5.CamelTestSupport;
 import org.apache.jena.vocabulary.RDF;
 import org.fcrepo.camel.FcrepoHeaders;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -28,7 +27,6 @@ import static java.util.UUID.randomUUID;
  * @author Aaron Coburn
  * @since November 7, 2014
  */
-@Disabled
 public class FcrepoPutIT extends CamelTestSupport {
 
     private static final String REPOSITORY = "http://fedora.info/definitions/v4/repository#";

--- a/src/test/java/org/fcrepo/camel/integration/FcrepoTransactionIT.java
+++ b/src/test/java/org/fcrepo/camel/integration/FcrepoTransactionIT.java
@@ -75,10 +75,10 @@ public class FcrepoTransactionIT extends CamelTestSupport {
     @Produce("direct:create")
     protected ProducerTemplate template;
 
+    // Camel 4 makes CamelTestSupport.setUp() final; a subclass @BeforeEach runs after
+    // the framework's own setup, matching the previous super.setUp()-first ordering.
     @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
-
+    public void setUpTransaction() throws Exception {
         txTemplate = new TransactionTemplate(txMgr);
         txTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRED);
         txTemplate.afterPropertiesSet();


### PR DESCRIPTION
Upgrade all dependencies to their latest versions and move the build to Java 21, building on the coverage tests from #172.

**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-4091

## What's new?

### Dependencies → latest
| Lib | From → To |
|---|---|
| Camel | 3.22.4 → **4.20.0** |
| Spring | 5.3.39 → **7.0.8** (aligned with Camel 4.20) |
| Jena | 4.10.0 → **6.1.0** |
| JUnit | 5.10.2 → **6.1.1** |
| Mockito | 5.11.0 → **5.23.0** |
| slf4j | 1.7.36 → **2.0.17** |
| logback | 1.2.13 → **1.5.37** |
| commons-io | 2.21.0 → **2.22.0** |
| surefire | 2.22.2 → **3.5.5** (2.x cannot run JUnit Platform 6) |

- Replaced the legacy `javax` JAXB shims (`jaxb-api` / `jaxb-core` / `javax.activation`) with **Jakarta JAXB 4** (`jakarta.xml.bind-api` + Glassfish `jaxb-runtime`).
- Added `org.messaginghub:pooled-jms` 3.2.2 (test scope) — Camel 4's ActiveMQ component pools connections via pooled-jms, which is no longer pulled in transitively.
- Dropped an unused `javaee-api` property.

### Build
- Target **JDK 21** (override `fcrepo-parent`'s hardcoded `release 11` in the compiler plugin).
- Updated GitHub Actions build/deploy from JDK 11 → JDK 21.

### Camel 3 → 4 API migration
- `Exchange.ACCEPT_CONTENT_TYPE` (removed) → new `FcrepoHeaders.ACCEPT_CONTENT_TYPE`, preserving the `CamelAcceptContentType` value so existing routes keep working.
- `exchange.adapt(ExtendedExchange.class)` (removed) → `exchange.getExchangeExtension()`.
- `@EndpointInject(uri=...)` / `@Produce(uri=...)` → value form.
- `CamelTestSupport.setUp()` is now `final` — reworked the affected IT overrides.

### Tests
- Re-enabled `FcrepoPutIT` — it was `@Disabled` with no documented reason and passes against the upgraded stack.
- `FcrepoTransactionIT` remains `@Disabled`: enabling it fails because the `required` transaction `Policy` cannot be resolved from the registry, consistent with its existing TODO that 6.x transactional support in `fcrepo-java-client` is not yet ready.

## How should this be tested?

`mvn clean verify` on JDK 21 — **103 unit tests + 25 integration tests pass**, 0 failures (only `FcrepoTransactionIT`'s 2 tests skipped, intentionally). Fedora 6.5.1 starts under Jetty 9.4 on JDK 21 and all integration tests pass.

> Note: Jetty is intentionally kept at 9.4.x — the integration tests deploy the `fcrepo-webapp` 6.5.1 (`javax`-servlet) war, which is incompatible with Jetty 12.

## Interested parties
@fcrepo/committers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
